### PR TITLE
fix: downgrade next to 13.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "bootstrap": "^5.2.3",
-    "next": "^13.3.0",
+    "next": "13.2.4",
     "react": "18.2.0",
     "react-bootstrap": "^2.7.2",
     "react-dom": "18.2.0"


### PR DESCRIPTION
Resolves missing req.body in delete api request causing deletes to fail with error "Please provide the list of DNS record ids as an array of string." (see this where the error triggers:  [line 17 ](https://github.com/th0th/cloudflare-dns/blob/30c0aa8f58a37f23bf0eefaa3f1f8a422dc49879/pages/api/zones/%5BzoneId%5D/dns-records/index.ts#L17) )